### PR TITLE
Add a empty route to deal with device's information.

### DIFF
--- a/src/app/api/device/route.ts
+++ b/src/app/api/device/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest, NextResponse } from 'next/server'
+import apiAxios from '../../../utils/apiAxios'
+
+export async function POST(request: NextRequest) {
+    // Este método deve receber o token do dispositivo que se registrar para receber notificações e armazenar no banco de dados
+    // request.body deve conter um json com o seguinte formato: {"token": "token string"}
+}


### PR DESCRIPTION
In this pull request I just add an empty route that should add the device's token to a database, so in the future the API will be able to select which device will receive notification.